### PR TITLE
fix: strip wildcards and truncate string filter values in default_apply_filters

### DIFF
--- a/app/storage/db.py
+++ b/app/storage/db.py
@@ -251,8 +251,11 @@ def default_apply_filters(
             if isinstance(value, (list, tuple)):
                 query = query.filter(attr.in_(value))
             elif isinstance(value, str):
-                # Use case-insensitive ILIKE for string filters
-                query = query.filter(attr.ilike(f"%{value}%"))
+                # Strip leading/trailing wildcards to prevent logical injection
+                # (e.g. "%a%b%" turning a cheap filter into a full-table scan)
+                # and enforce a max length to limit DB load.
+                sanitized = value.strip("%")[:255]
+                query = query.filter(attr.ilike(f"%{sanitized}%"))
             else:
                 query = query.filter(attr == value)
         else:

--- a/tests/unit/pagination/test_pagination.py
+++ b/tests/unit/pagination/test_pagination.py
@@ -622,6 +622,45 @@ class TestDefaultApplyFilters:
         assert filtered_query is not None
         assert isinstance(filtered_query, Select)
 
+    def test_filter_strips_leading_trailing_wildcards(self):
+        """Wildcard characters at start/end of string values are stripped."""
+        import re
+
+        from sqlmodel import select
+
+        query = select(PaginationTestModel)
+        filters = {"name": "%a%b%c%"}
+
+        filtered_query = default_apply_filters(
+            query, PaginationTestModel, filters
+        )
+
+        compiled = str(
+            filtered_query.compile(compile_kwargs={"literal_binds": True})
+        )
+        # SQLAlchemy compiles ILIKE as lower(...) LIKE lower(...)
+        # Wildcard-stripped value %a%b%c% should appear, not %%a%b%c%%
+        assert re.search(r"lower\('%a%b%c%'\)", compiled)
+        assert "%%a%b%c%%" not in compiled
+
+    def test_filter_truncates_long_string_values(self):
+        """String filter values longer than 255 chars are truncated."""
+        from sqlmodel import select
+
+        long_value = "a" * 300
+        query = select(PaginationTestModel)
+        filters = {"name": long_value}
+
+        filtered_query = default_apply_filters(
+            query, PaginationTestModel, filters
+        )
+
+        compiled = str(
+            filtered_query.compile(compile_kwargs={"literal_binds": True})
+        )
+        # The bound value should be at most 255 chars (plus surrounding % wildcards)
+        assert "a" * 256 not in compiled
+
     def test_filter_empty_dict(self):
         """
         Test empty filters dict returns query unchanged.


### PR DESCRIPTION
## Summary

Fixes #195 — `default_apply_filters` passed user-supplied string values directly into `ILIKE '%{value}%'`, allowing logical injection (e.g. `%a%b%c%` becoming `%%a%b%c%%` which turns a cheap filter into an expensive full-table scan).

## Changes

- Strip leading/trailing `%` from string filter values before interpolation
- Truncate string filter values to 255 characters to bound DB load

## Test plan

- [x] `test_filter_strips_leading_trailing_wildcards` — verifies `%a%b%c%` becomes `%a%b%c%` not `%%a%b%c%%`
- [x] `test_filter_truncates_long_string_values` — verifies 300-char input is truncated to 255
- [x] All 8 `TestDefaultApplyFilters` tests pass