### PR TITLE
fix: separate transient from fatal broadcast errors in ConnectionManager

### DIFF
--- a/app/managers/websocket_connection_manager.py
+++ b/app/managers/websocket_connection_manager.py
@@ -6,6 +6,7 @@ from starlette.websockets import WebSocketDisconnect
 
 from app.logging import logger
 from app.schemas.response import BroadcastDataModel
+from app.utils.metrics import MetricsCollector
 
 
 class ConnectionManager:
@@ -110,21 +111,21 @@ class ConnectionManager:
             try:
                 await connection.send_json(message.model_dump(mode="json"))
             except (WebSocketDisconnect, ConnectionError, RuntimeError) as e:
-                # WebSocketDisconnect: Client disconnected
-                # ConnectionError: Network errors
-                # RuntimeError: WebSocket in invalid state
+                # Fatal connection errors — client is gone, clean up
                 logger.warning(
                     f"Failed to send to connection {id(connection)} "
                     f"(key: {session_key}): {e}"
                 )
                 self.disconnect(session_key)
             except Exception as e:  # noqa: BLE001
-                # Catch-all for unexpected send errors
-                logger.warning(
-                    f"Unexpected error sending to connection {id(connection)} "
-                    f"(key: {session_key}): {e}"
+                # Transient/unexpected error — log and skip, do NOT disconnect.
+                # The connection may still be valid; disconnecting here would
+                # drop healthy clients on serialization errors or buffer blips.
+                MetricsCollector.record_ws_broadcast_error()
+                logger.error(
+                    f"Unexpected broadcast error for connection {id(connection)} "
+                    f"(key: {session_key}), skipping send: {e}"
                 )
-                self.disconnect(session_key)
 
         await asyncio.gather(
             *[safe_send(key, conn) for key, conn in connections_snapshot],

--- a/app/utils/metrics/__init__.py
+++ b/app/utils/metrics/__init__.py
@@ -70,6 +70,7 @@ from app.utils.metrics.redis import (
 from app.utils.metrics.websocket import (
     get_active_websocket_connections,
     get_websocket_health_info,
+    ws_broadcast_errors_total,
     ws_connections_active,
     ws_connections_total,
     ws_message_processing_duration_seconds,
@@ -104,6 +105,7 @@ __all__ = [
     "ws_messages_received_total",
     "ws_messages_sent_total",
     "ws_message_processing_duration_seconds",
+    "ws_broadcast_errors_total",
     "get_active_websocket_connections",
     "get_websocket_health_info",
     # Database metrics

--- a/app/utils/metrics/collector.py
+++ b/app/utils/metrics/collector.py
@@ -61,6 +61,13 @@ class MetricsCollector:
         ws_messages_sent_total.inc()
 
     @staticmethod
+    def record_ws_broadcast_error() -> None:
+        """Record unexpected broadcast error (connection skipped, not disconnected)."""
+        from app.utils.metrics import ws_broadcast_errors_total
+
+        ws_broadcast_errors_total.inc()
+
+    @staticmethod
     def record_ws_message_processing(pkg_id: int, duration: float) -> None:
         """
         Record WebSocket message processing duration.

--- a/app/utils/metrics/websocket.py
+++ b/app/utils/metrics/websocket.py
@@ -37,6 +37,11 @@ ws_message_processing_duration_seconds = get_or_create_histogram(
     buckets=(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0),
 )
 
+ws_broadcast_errors_total = get_or_create_counter(
+    "ws_broadcast_errors_total",
+    "Total unexpected errors during WebSocket broadcast (connection skipped, not disconnected)",
+)
+
 
 # Helper Functions
 
@@ -81,6 +86,7 @@ __all__ = [
     "ws_messages_received_total",
     "ws_messages_sent_total",
     "ws_message_processing_duration_seconds",
+    "ws_broadcast_errors_total",
     "get_active_websocket_connections",
     "get_websocket_health_info",
 ]

--- a/tests/integration/test_websocket_connection_manager.py
+++ b/tests/integration/test_websocket_connection_manager.py
@@ -5,10 +5,11 @@ This module tests the ConnectionManager functionality including
 connection tracking and broadcasting.
 """
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import WebSocket
+from starlette.websockets import WebSocketDisconnect
 
 from app.managers.websocket_connection_manager import ConnectionManager
 from app.schemas.response import BroadcastDataModel
@@ -145,15 +146,41 @@ class TestConnectionManager:
         mock_ws3.send_json.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_broadcast_handles_send_error(self):
-        """Test broadcast handles send errors gracefully."""
+    async def test_broadcast_disconnects_on_websocket_disconnect(self):
+        """Fatal WebSocketDisconnect errors remove the connection."""
         manager = ConnectionManager()
         mock_ws1 = MagicMock(spec=WebSocket)
         mock_ws2 = MagicMock(spec=WebSocket)
 
-        # First connection will fail to send
+        mock_ws1.send_json = AsyncMock(side_effect=WebSocketDisconnect())
+        mock_ws2.send_json = AsyncMock()
+
+        manager.connect("session:test1", mock_ws1)
+        manager.connect("session:test2", mock_ws2)
+
+        broadcast_msg = BroadcastDataModel(
+            pkg_id=1, status_code=0, data={"message": "test"}
+        )
+
+        await manager.broadcast(broadcast_msg)
+
+        # Disconnected client removed
+        assert "session:test1" not in manager.connections
+        # Healthy client still connected and received message
+        mock_ws2.send_json.assert_called_once()
+        assert "session:test2" in manager.connections
+
+    @pytest.mark.asyncio
+    async def test_broadcast_skips_on_unexpected_error_without_disconnecting(
+        self,
+    ):
+        """Unexpected errors skip the send but keep the connection alive."""
+        manager = ConnectionManager()
+        mock_ws1 = MagicMock(spec=WebSocket)
+        mock_ws2 = MagicMock(spec=WebSocket)
+
         mock_ws1.send_json = AsyncMock(
-            side_effect=Exception("Connection closed")
+            side_effect=ValueError("serialization error")
         )
         mock_ws2.send_json = AsyncMock()
 
@@ -161,17 +188,18 @@ class TestConnectionManager:
         manager.connect("session:test2", mock_ws2)
 
         broadcast_msg = BroadcastDataModel(
-            pkg_id=1,
-            status_code=0,
-            data={"message": "test"},
+            pkg_id=1, status_code=0, data={"message": "test"}
         )
 
-        # Should not raise exception
-        await manager.broadcast(broadcast_msg)
+        with patch(
+            "app.managers.websocket_connection_manager.MetricsCollector.record_ws_broadcast_error"
+        ) as mock_metric:
+            await manager.broadcast(broadcast_msg)
 
-        # Failed connection should be disconnected
-        assert "session:test1" not in manager.connections
-
-        # Second connection should still receive message
+        # Connection NOT removed — error was transient
+        assert "session:test1" in manager.connections
+        # Metric incremented
+        mock_metric.assert_called_once()
+        # Other connection still received message
         mock_ws2.send_json.assert_called_once()
         assert "session:test2" in manager.connections


### PR DESCRIPTION
## Summary

Fixes #197 — any unexpected exception during `broadcast()` was disconnecting the client, including transient errors like serialization failures that don't indicate the connection is gone.

## Changes

- **Fatal errors** (`WebSocketDisconnect`, `ConnectionError`, `RuntimeError`): client is disconnected as before
- **Unexpected errors**: log at `ERROR` level, increment `ws_broadcast_errors_total` metric, skip the send — connection stays alive
- Added `ws_broadcast_errors_total` Prometheus counter for observability
- Added `MetricsCollector.record_ws_broadcast_error()` to the facade

## Test plan

- [x] `test_broadcast_disconnects_on_websocket_disconnect` — fatal errors still remove the connection
- [x] `test_broadcast_skips_on_unexpected_error_without_disconnecting` — transient errors keep connection alive and increment metric
- [x] All 10 connection manager tests pass