### PR TITLE
fix: accept optional session in get_paginated_results to avoid split transactions

### DIFF
--- a/app/api/ws/handlers/author_handlers.py
+++ b/app/api/ws/handlers/author_handlers.py
@@ -213,14 +213,16 @@ async def get_paginated_authors_handler(
             )
 
     # Get paginated results with type-safe filters
-    authors, meta = await get_paginated_results(
-        Author,
-        page=page,
-        per_page=per_page,
-        filters=filters,
-        cursor=cursor,
-        eager_load=eager_load,
-    )
+    async with async_session() as session:
+        authors, meta = await get_paginated_results(
+            Author,
+            page=page,
+            per_page=per_page,
+            session=session,
+            filters=filters,
+            cursor=cursor,
+            eager_load=eager_load,
+        )
 
     return ResponseModel(
         pkg_id=request.pkg_id,

--- a/app/storage/db.py
+++ b/app/storage/db.py
@@ -131,6 +131,7 @@ async def get_paginated_results(
     page: int = 1,
     per_page: int | None = None,
     *,
+    session: AsyncSession | None = None,
     filters: dict[str, Any] | PydanticBaseModel | None = None,
     apply_filters: (
         Callable[[Select, Type[GenericSQLModelType], dict[str, Any]], Select]
@@ -159,6 +160,9 @@ async def get_paginated_results(
         model (Type[GenericSQLModelType]): The SQLModel class to query.
         page (int, optional): The page number to retrieve (offset pagination). Defaults to 1.
         per_page (int | None, optional): The number of results to return per page. Defaults to app_settings.DEFAULT_PAGE_SIZE. Capped at MAX_PAGE_SIZE.
+        session (AsyncSession | None, optional): Existing DB session to reuse. When provided,
+            pagination runs in the same transaction as the caller — uncommitted writes are
+            visible to the query. When None (default), a new session is opened internally.
         filters (dict[str, Any] | PydanticBaseModel | None, optional): Filters to apply to the query. Can be a dict (legacy) or Pydantic BaseModel (type-safe). Pydantic models should inherit from app.schemas.filters.BaseFilter.
         apply_filters (Callable[[Select, Type[GenericSQLModelType], dict[str, Any]], Select] | None, optional): A custom function to apply filters to the query. If not provided, the `default_apply_filters` function will be used.
         skip_count (bool, optional): Skip the count query for performance. When True, total will be 0. Defaults to False.
@@ -211,18 +215,28 @@ async def get_paginated_results(
     # Build query with filters and eager loading
     query = build_query(model, filter_dict, apply_filters, eager_load)
 
-    # Select and execute pagination strategy
-    async with async_session() as session:
+    # Select and execute pagination strategy.
+    # If the caller passes a session, reuse it so pagination runs in the same
+    # transaction — uncommitted writes remain visible to the query.
+    # Otherwise open a new session (backward-compatible default).
+    async def _run(
+        s: AsyncSession,
+    ) -> tuple[list[GenericSQLModelType], MetadataModel]:
         strategy = select_strategy(
-            session=session,
+            session=s,
             cursor=cursor,
             page=page,
             skip_count=skip_count,
             filter_dict=filter_dict,
             apply_filters_func=apply_filters,
         )
-
         return await strategy.paginate(query, model, per_page)
+
+    if session is not None:
+        return await _run(session)
+
+    async with async_session() as new_session:
+        return await _run(new_session)
 
 
 def default_apply_filters(

--- a/tests/unit/pagination/test_pagination.py
+++ b/tests/unit/pagination/test_pagination.py
@@ -532,6 +532,49 @@ class TestGetPaginatedResults:
             # Should complete successfully but log warning
             assert len(results) == 1
 
+    @pytest.mark.asyncio
+    async def test_pagination_uses_provided_session(self):
+        """When session= is passed, get_paginated_results uses it instead of opening a new one."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from app.models.author import Author
+        from app.storage.db import get_paginated_results
+
+        mock_authors = [Author(id=1, name="Author 1")]
+
+        mock_count_result = MagicMock()
+        mock_count_result.one.return_value = 1
+
+        mock_data_result = MagicMock()
+        mock_data_result.all.return_value = mock_authors
+
+        mock_session = AsyncMock()
+        mock_session.exec = AsyncMock(
+            side_effect=[mock_count_result, mock_data_result]
+        )
+
+        mock_session_factory = MagicMock()  # should NOT be called
+
+        with (
+            patch("app.storage.db.async_session", mock_session_factory),
+            patch(
+                "app.storage.pagination.offset.get_cached_count",
+                AsyncMock(return_value=None),
+            ),
+            patch(
+                "app.storage.pagination.offset.set_cached_count", AsyncMock()
+            ),
+        ):
+            results, meta = await get_paginated_results(
+                Author, page=1, per_page=1, session=mock_session
+            )
+
+        # Provided session was used
+        mock_session.exec.assert_called()
+        # async_session() was NOT called — no new session opened
+        mock_session_factory.assert_not_called()
+        assert len(results) == 1
+
 
 class TestDefaultApplyFilters:
     """Tests for default_apply_filters function."""


### PR DESCRIPTION
## Summary

Fixes #194 — `get_paginated_results()` always opened its own `async_session()`, running pagination in a separate transaction from the caller. Uncommitted writes in the caller's session were invisible to the pagination query.

## Changes

- Added optional `session: AsyncSession | None = None` parameter to `get_paginated_results()`
- When provided, reuses the caller's session — pagination runs in the same transaction
- When `None` (default), opens a new session for full backward compatibility
- Updated `get_paginated_authors_handler` (WebSocket) to pass its own session

## Test plan

- [x] `test_pagination_uses_provided_session` — verifies provided session is used and `async_session()` is not called
- [x] All 118 pagination unit tests pass