### PR TITLE
fix: clear and reload handler registry on hot reload (#196, #198)

### DIFF
--- a/app/api/http/author.py
+++ b/app/api/http/author.py
@@ -26,7 +26,7 @@ from app.commands.author_commands import (
     UpdateAuthorCommand,
     UpdateAuthorInput,
 )
-from app.dependencies import AuthorRepoDep
+from app.dependencies import AuthorRepoDep, ReadAuthorRepoDep
 from fastapi_keycloak_rbac.dependencies import require_roles
 from app.security.roles import Role
 from app.models.author import Author
@@ -47,7 +47,7 @@ router = APIRouter(prefix="/authors", tags=["authors"])
 )
 @handle_http_errors
 async def get_authors(
-    repo: AuthorRepoDep,
+    repo: ReadAuthorRepoDep,
     id: int | None = None,
     name: str | None = None,
     search: str | None = None,
@@ -201,7 +201,6 @@ async def delete_author(
 )
 @handle_http_errors
 async def get_paginated_authors(
-    repo: AuthorRepoDep,
     page: int = 1,
     per_page: int = app_settings.DEFAULT_PAGE_SIZE,
     cursor: str | None = None,

--- a/app/api/ws/handlers/__init__.py
+++ b/app/api/ws/handlers/__init__.py
@@ -1,11 +1,19 @@
 import importlib
 import pkgutil
+import sys
 
 
 def load_handlers():  # type: ignore[no-untyped-def]
     """
     Dynamically loads all ws handlers in the handlers package to
     trigger the registration of handlers via decorators.
+
+    Reloads already-cached modules so that decorators re-run after the
+    handler registry has been cleared (e.g. on uvicorn hot-reload).
     """
     for _, module_name, _ in pkgutil.iter_modules(__path__):
-        importlib.import_module(f"{__name__}.{module_name}")
+        full_name = f"{__name__}.{module_name}"
+        if full_name in sys.modules:
+            importlib.reload(sys.modules[full_name])
+        else:
+            importlib.import_module(full_name)

--- a/app/dependencies/__init__.py
+++ b/app/dependencies/__init__.py
@@ -27,13 +27,17 @@ from fastapi import Depends
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.repositories.author_repository import AuthorRepository
-from app.storage.db import get_session
+from app.storage.db import get_read_session, get_session
 
 # ============================================================================
 # Database Session Dependencies
 # ============================================================================
 
 SessionDep = Annotated[AsyncSession, Depends(get_session)]
+"""Write session — commits on success. Use for handlers that mutate data."""
+
+ReadSessionDep = Annotated[AsyncSession, Depends(get_read_session)]
+"""Read-only session — no commit. Use for GET/read handlers to avoid a no-op round-trip."""
 
 
 # ============================================================================
@@ -43,7 +47,7 @@ SessionDep = Annotated[AsyncSession, Depends(get_session)]
 
 def get_author_repository(session: SessionDep) -> AuthorRepository:
     """
-    Get author repository with injected database session.
+    Get author repository with injected write database session.
 
     Args:
         session: Database session injected by FastAPI.
@@ -55,3 +59,23 @@ def get_author_repository(session: SessionDep) -> AuthorRepository:
 
 
 AuthorRepoDep = Annotated[AuthorRepository, Depends(get_author_repository)]
+
+
+def get_read_author_repository(session: ReadSessionDep) -> AuthorRepository:
+    """
+    Get author repository with injected read-only database session.
+
+    Use for GET endpoints that do not write to the database.
+
+    Args:
+        session: Read-only database session injected by FastAPI.
+
+    Returns:
+        AuthorRepository instance with session.
+    """
+    return AuthorRepository(session)
+
+
+ReadAuthorRepoDep = Annotated[
+    AuthorRepository, Depends(get_read_author_repository)
+]

--- a/app/routing.py
+++ b/app/routing.py
@@ -1,7 +1,8 @@
 import os
 import pkgutil
+import sys
 from collections.abc import Callable
-from importlib import import_module
+from importlib import import_module, reload
 from typing import Any
 
 from fastapi import APIRouter
@@ -126,15 +127,6 @@ class PackageRouter:
 
         def decorator(func: HandlerCallableType) -> HandlerCallableType:
             for pkg_id in pkg_ids:
-                # Check if handler is already registered (idempotent for reload)
-                if pkg_id in self.handlers_registry:
-                    # Skip if same handler, raise if different
-                    if self.handlers_registry[pkg_id] != func:
-                        raise ValueError(
-                            f"Different handler already registered for pkg_id {pkg_id}"
-                        )
-                    continue
-
                 self.handlers_registry[pkg_id] = func
 
                 # Only store validators if both schema and callback are provided
@@ -305,11 +297,6 @@ class PackageRouter:
 pkg_router = PackageRouter()
 
 
-# Track registered modules to prevent duplicate logging
-_registered_http_modules: set[str] = set()
-_registered_ws_modules: set[str] = set()
-
-
 def collect_subrouters() -> APIRouter:
     """
     Collects and registers all API and WebSocket routers for the application.
@@ -320,6 +307,11 @@ def collect_subrouters() -> APIRouter:
 
     The main `APIRouter` instance is then returned, allowing it to be used as the entry point for the application's API.
     """
+    # Clear registries so hot-reload gets fresh handler references (#196)
+    pkg_router.handlers_registry.clear()
+    pkg_router.validators_registry.clear()
+    pkg_router.permissions_registry.clear()
+
     # Initialize main router
     main_router: APIRouter = APIRouter()
 
@@ -329,30 +321,26 @@ def collect_subrouters() -> APIRouter:
 
     # Get API routers
     for _, module, _ in pkgutil.iter_modules([f"{app_dir}/api/http"]):
-        # Get api module
-        api = import_module(f".{module}", package=f"{app_name}.api.http")
-
-        # Add api router to main router
+        full_name = f"{app_name}.api.http.{module}"
+        api = (
+            reload(sys.modules[full_name])
+            if full_name in sys.modules
+            else import_module(f".{module}", package=f"{app_name}.api.http")
+        )
         main_router.include_router(api.router)
-
-        # Only log on first registration
-        if module not in _registered_http_modules:
-            logger.info(f'Register "{module}" api')
-            _registered_http_modules.add(module)
+        logger.info(f'Register "{module}" api')
 
     # Get WS routers
     for _, module, _ in pkgutil.iter_modules([f"{app_dir}/api/ws/consumers"]):
-        # Get ws module
-        ws_consumer = import_module(
-            f".{module}", package=f"{app_name}.api.ws.consumers"
+        full_name = f"{app_name}.api.ws.consumers.{module}"
+        ws_consumer = (
+            reload(sys.modules[full_name])
+            if full_name in sys.modules
+            else import_module(
+                f".{module}", package=f"{app_name}.api.ws.consumers"
+            )
         )
-
-        # Add ws router to main router
         main_router.include_router(ws_consumer.router)
-
-        # Only log on first registration
-        if module not in _registered_ws_modules:
-            logger.info(f'Register "{module}" websocket consumer')
-            _registered_ws_modules.add(module)
+        logger.info(f'Register "{module}" websocket consumer')
 
     return main_router

--- a/app/storage/db.py
+++ b/app/storage/db.py
@@ -75,7 +75,12 @@ async def wait_and_init_db(
 
 async def get_session() -> AsyncSession:
     """
-    Get an asynchronous session from the SQLAlchemy session factory.
+    Get an asynchronous write session from the SQLAlchemy session factory.
+
+    Commits on success, rolls back on IntegrityError or SQLAlchemyError.
+    Use for handlers that write to the database.
+    For read-only handlers use :func:`get_read_session` to avoid the
+    unnecessary commit round-trip.
 
     Yields:
         AsyncSession: An asynchronous SQLAlchemy session.
@@ -88,6 +93,26 @@ async def get_session() -> AsyncSession:
             await session.rollback()
             logger.error(f"Database integrity error: {ex}")
             raise
+        except SQLAlchemyError as ex:
+            await session.rollback()
+            logger.error(f"Database error: {ex}")
+            raise
+
+
+async def get_read_session() -> AsyncSession:
+    """
+    Get an asynchronous read-only session from the SQLAlchemy session factory.
+
+    Does NOT commit after the request — avoids a no-op transaction round-trip
+    to PostgreSQL for handlers that only read data (e.g. GET endpoints).
+    Rolls back on any SQLAlchemy error to release the connection cleanly.
+
+    Yields:
+        AsyncSession: An asynchronous SQLAlchemy session.
+    """
+    async with async_session() as session:
+        try:
+            yield session
         except SQLAlchemyError as ex:
             await session.rollback()
             logger.error(f"Database error: {ex}")

--- a/tests/unit/rbac/test_routing.py
+++ b/tests/unit/rbac/test_routing.py
@@ -1,7 +1,9 @@
 """Tests for package routing functionality."""
 
+import pytest
+
 from app.api.ws.constants import PkgID
-from app.routing import PackageRouter, collect_subrouters
+from app.routing import PackageRouter, collect_subrouters, pkg_router
 from app.schemas.request import RequestModel
 from app.schemas.response import ResponseModel
 
@@ -93,6 +95,20 @@ class TestPackageRouter:
 
 class TestCollectSubrouters:
     """Test HTTP and WebSocket router collection."""
+
+    @pytest.fixture(autouse=True)
+    def restore_pkg_router(self):
+        """Restore global pkg_router registries after each test."""
+        handlers = dict(pkg_router.handlers_registry)
+        validators = dict(pkg_router.validators_registry)
+        permissions = dict(pkg_router.permissions_registry)
+        yield
+        pkg_router.handlers_registry.clear()
+        pkg_router.handlers_registry.update(handlers)
+        pkg_router.validators_registry.clear()
+        pkg_router.validators_registry.update(validators)
+        pkg_router.permissions_registry.clear()
+        pkg_router.permissions_registry.update(permissions)
 
     def test_collect_subrouters_returns_api_router(self):
         """Test that collect_subrouters returns an APIRouter instance."""


### PR DESCRIPTION
## Summary
- Fixes #196: `collect_subrouters()` now clears all registries then uses `importlib.reload()` for cached consumer/handler modules so decorators re-execute with fresh references on uvicorn hot-reload
- Fixes #198: Adds `get_read_session()` + `ReadSessionDep` / `ReadAuthorRepoDep`; GET endpoints no longer trigger a no-op `COMMIT` round-trip to PostgreSQL
- Removes stale `_registered_http_modules` / `_registered_ws_modules` sets that suppressed log output without solving the stale-ref problem
- Adds `restore_pkg_router` autouse fixture to `TestCollectSubrouters` to prevent test pollution

## Test plan
- [ ] Unit tests pass: `uv run pytest tests/ --ignore=tests/integration`
- [ ] `GET /authors` and `GET /authors/paginated` use read-only session (no DB commit)
- [ ] Hot-reload (`make serve`) picks up handler changes without stale references

Fixes #196, #198